### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,12 +14,7 @@
   "bugs": {
     "url": "https://github.com/assemble/fs-utils/issues"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/assemble/fs-utils/blob/master/LICENSE-MIT"
-    }
-  ],
+  "license": "MIT",
   "main": "index.js",
   "scripts": {
     "test": "mocha -R spec"


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/