### PR TITLE
Fix typo

### DIFF
--- a/index.js
+++ b/index.js
@@ -843,7 +843,7 @@ var resolve = exports.resolve = function(filepath) {
  */
 
 exports.relative = function(a, b) {
-  return utils.rel.apply(utils.rel, arguments);
+  return utils.relative.apply(utils.relative, arguments);
 };
 
 /**


### PR DESCRIPTION
`.relative()` does not work in 0.6.4.
I think `utils.rel` should be `utils.relative`. 